### PR TITLE
Changes from Procursus's firmware

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,15 +13,18 @@ TARGET_ARCH			?= arm64
 TARGET_SYSROOT		?= $(shell xcrun --sdk $(TARGET_PLATFORM) --show-sdk-path)
 
 ifeq (,$(findstring -arch ,$(CFLAGS)))
-	CFLAGS			+= -arch $(TARGET_ARCH)
+CFLAGS += -arch $(TARGET_ARCH)
 endif
 
 ifeq (,$(findstring -isysroot ,$(CFLAGS)))
-	CFLAGS			+= -isysroot $(TARGET_SYSROOT)
+CFLAGS += -isysroot $(TARGET_SYSROOT)
 endif
 
-CFLAGS				+= -m$(TARGET_PLATFORM)-version-min=$(TARGET_VERSION)
+CFLAGS += -m$(TARGET_PLATFORM)-version-min=$(TARGET_VERSION)
 
+ifeq ($(DEBUG),1)
+CFLAGS += -DDEBUG
+endif
 
 all:: src/*.m
 	mkdir -p build

--- a/src/DeviceInfo.h
+++ b/src/DeviceInfo.h
@@ -11,15 +11,15 @@
 
 + (instancetype)sharedDevice;
 
-@property (readonly) BOOL ios;
 @property (readonly) NSString *cpuArchitecture;
+@property (readonly) NSString *cpuSubArchitecture;
 
 - (NSString *)getOperatingSystemVersion;    // e.g. 13.3.1
 - (NSString *)getModelName;                 // e.g. iPhone7,1   -> iphone
 - (NSString *)getModelVersion;              // e.g. iPhone7,1   -> 7.1
-- (NSString *)getDebianArchitecture;        // iphoneos-arm or cydia
-- (NSString *)getOperatingSystem;           // ios or macos
-- (NSString *)getDPKGDataDirectory;         // /var/lib/dpkg or /Library/Cydia/dpkg
+- (NSString *)getDebianArchitecture;        // *os-arm or darwin-arm64e
+- (NSString *)getOperatingSystem;           // *os
+- (NSString *)getDPKGDataDirectory;         // /var/lib/dpkg
 - (NSDictionary *)getCapabilities;          // filtered output of gssc to only include capabilites the device actually has
 - (NSString *)getCoreFoundationVersion;     // e.g. 1674.11
 - (NSString *)getOperatingSystemType;       // e.g. Darwin

--- a/src/Firmware.h
+++ b/src/Firmware.h
@@ -6,6 +6,18 @@
 
 #import <spawn.h>
 
+#ifndef MAINTAINER
+    #define MAINTAINER @"Steve Jobs <steve@apple.com>"
+#endif
+
+#ifdef DEBUG
+    #define DEBUGLOG(str, ...) do { \
+        NSLog(@str, ##__VA_ARGS__); \
+    } while(0)
+#else
+    #define DEBUGLOG(str, ...)
+#endif
+
 @interface Firmware : NSObject
 
 - (void)exitWithError:(NSError *)error andMessage:(NSString *)message;


### PR DESCRIPTION
This still needs a change to detect the install prefix of firmware/the bootstrap (/opt/procursus on macos, for example).